### PR TITLE
feat: Docker-based Python sandbox with strict isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,27 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  sandbox:
+    name: sandbox image + smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build sandbox image
+        run: pnpm sandbox:build
+
+      - name: Sandbox smoke test
+        run: pnpm sandbox:smoke

--- a/docker/python-runner/Dockerfile
+++ b/docker/python-runner/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY runner.py /usr/local/bin/runner.py
+RUN chmod 755 /usr/local/bin/runner.py
+
+WORKDIR /sandbox
+USER 65534:65534
+
+ENTRYPOINT ["python", "-I", "/usr/local/bin/runner.py"]

--- a/docker/python-runner/runner.py
+++ b/docker/python-runner/runner.py
@@ -1,0 +1,45 @@
+"""Sandbox harness for gauntleet.
+
+Wire protocol on stdin:
+  Line 1: ASCII header "GLT:<n>\n" — <n> is the byte length of the source that follows.
+  Bytes : <n> bytes of UTF-8 Python source.
+  Bytes : remaining bytes (if any) are passed through to the user code as stdin.
+
+Source is compiled and exec'd with __name__ = '__main__'. Anything the user
+program writes to stdout/stderr is captured by the host. Exit code is the
+program's exit code (0 on normal return, non-zero on uncaught exception or
+explicit sys.exit()).
+"""
+
+import sys
+
+
+def main() -> None:
+    header = sys.stdin.buffer.readline()
+    if not header.startswith(b"GLT:"):
+        sys.stderr.write("sandbox protocol error: missing GLT header\n")
+        sys.exit(2)
+    try:
+        source_len = int(header[4:].rstrip(b"\r\n"))
+    except ValueError:
+        sys.stderr.write("sandbox protocol error: invalid GLT length\n")
+        sys.exit(2)
+
+    source_bytes = sys.stdin.buffer.read(source_len)
+    if len(source_bytes) != source_len:
+        sys.stderr.write("sandbox protocol error: truncated source\n")
+        sys.exit(2)
+
+    try:
+        source = source_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        sys.stderr.write("sandbox protocol error: source is not valid UTF-8\n")
+        sys.exit(2)
+
+    code_obj = compile(source, "<user>", "exec")
+    # Any remaining bytes on stdin are still available to the user program.
+    exec(code_obj, {"__name__": "__main__"})
+
+
+if __name__ == "__main__":
+    main()

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
-    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\""
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
+    "sandbox:build": "docker build -t gauntleet-python-runner:latest docker/python-runner",
+    "sandbox:smoke": "pnpm --filter @gauntleet/sandbox smoke"
   },
   "devDependencies": {
     "prettier": "^3.4.2",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -6,9 +6,12 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "smoke": "tsx scripts/smoke.ts"
   },
   "devDependencies": {
+    "@types/node": "^22.10.5",
+    "tsx": "^4.19.2",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/sandbox/scripts/smoke.ts
+++ b/packages/sandbox/scripts/smoke.ts
@@ -1,0 +1,143 @@
+import { runPython, type RunPythonResult } from "../src/index.js";
+
+interface Case {
+  name: string;
+  code: string;
+  stdin?: string;
+  timeoutMs?: number;
+  memoryMb?: number;
+  expect: (r: RunPythonResult) => string | null;
+}
+
+const cases: Case[] = [
+  {
+    name: "hello world",
+    code: 'print("hello")',
+    expect: (r) =>
+      r.exitCode === 0 && r.stdout.trim() === "hello"
+        ? null
+        : `expected exit=0 stdout="hello", got ${describe(r)}`,
+  },
+  {
+    name: "stdin pass-through",
+    code: "import sys\nprint(sys.stdin.read().strip())",
+    stdin: "ping\n",
+    expect: (r) =>
+      r.exitCode === 0 && r.stdout.trim() === "ping"
+        ? null
+        : `expected stdout="ping", got ${describe(r)}`,
+  },
+  {
+    name: "uncaught exception → non-zero exit",
+    code: 'raise ValueError("nope")',
+    expect: (r) =>
+      r.exitCode !== 0 && /ValueError/.test(r.stderr)
+        ? null
+        : `expected non-zero exit + ValueError in stderr, got ${describe(r)}`,
+  },
+  {
+    name: "infinite loop times out",
+    code: "while True: pass",
+    timeoutMs: 1500,
+    expect: (r) => (r.timedOut ? null : `expected timedOut=true, got ${describe(r)}`),
+  },
+  {
+    name: "fork bomb hits pid limit",
+    code:
+      "import os\n" +
+      "for _ in range(2000):\n" +
+      "    try: os.fork()\n" +
+      "    except OSError: pass\n",
+    timeoutMs: 3000,
+    expect: (r) =>
+      r.exitCode !== 0 || r.timedOut ? null : `expected pid limit failure, got ${describe(r)}`,
+  },
+  {
+    name: "network is blocked",
+    code:
+      "import socket\n" +
+      "try:\n" +
+      "    s = socket.socket()\n" +
+      "    s.settimeout(2)\n" +
+      "    s.connect(('1.1.1.1', 80))\n" +
+      "    print('CONNECTED')\n" +
+      "except Exception as e:\n" +
+      "    print('BLOCKED', type(e).__name__)\n",
+    timeoutMs: 5000,
+    expect: (r) =>
+      r.stdout.startsWith("BLOCKED") ? null : `network appeared reachable, got ${describe(r)}`,
+  },
+  {
+    name: "writes to /etc are blocked (read-only fs)",
+    code:
+      "try:\n" +
+      "    open('/etc/gauntleet_breach', 'w').write('nope')\n" +
+      "    print('WROTE')\n" +
+      "except Exception as e:\n" +
+      "    print('BLOCKED', type(e).__name__)\n",
+    expect: (r) =>
+      r.stdout.startsWith("BLOCKED") ? null : `was able to write to /etc, got ${describe(r)}`,
+  },
+  {
+    name: "writes to /tmp are allowed (tmpfs)",
+    code:
+      "open('/tmp/gauntleet_ok','w').write('ok')\n" + "print(open('/tmp/gauntleet_ok').read())\n",
+    expect: (r) =>
+      r.exitCode === 0 && r.stdout.trim() === "ok"
+        ? null
+        : `tmpfs write/read failed, got ${describe(r)}`,
+  },
+  {
+    name: "memory bomb hits memory limit",
+    code: "x = bytearray(1024 * 1024 * 512)\nprint('ALLOC')",
+    memoryMb: 64,
+    expect: (r) =>
+      r.exitCode !== 0 && !r.stdout.includes("ALLOC")
+        ? null
+        : `memory limit not enforced, got ${describe(r)}`,
+  },
+];
+
+function describe(r: RunPythonResult): string {
+  const parts = [
+    `exit=${r.exitCode}`,
+    `timedOut=${r.timedOut}`,
+    `oom=${r.oom}`,
+    `dur=${r.durationMs}ms`,
+    `stdout=${JSON.stringify(r.stdout.slice(0, 120))}`,
+    `stderr=${JSON.stringify(r.stderr.slice(0, 120))}`,
+  ];
+  return `{ ${parts.join(", ")} }`;
+}
+
+async function main(): Promise<void> {
+  let failures = 0;
+  for (const c of cases) {
+    const start = Date.now();
+    const result = await runPython({
+      code: c.code,
+      stdin: c.stdin,
+      timeoutMs: c.timeoutMs,
+      memoryMb: c.memoryMb,
+    });
+    const ms = Date.now() - start;
+    const failure = c.expect(result);
+    if (failure) {
+      failures++;
+      console.error(`✗ ${c.name} (${ms}ms)\n   ${failure}`);
+    } else {
+      console.log(`✓ ${c.name} (${ms}ms)`);
+    }
+  }
+  console.log();
+  if (failures > 0) {
+    console.error(`${failures} sandbox check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("All sandbox checks passed.");
+}
+
+main().catch((err) => {
+  console.error("smoke test crashed:", err);
+  process.exit(1);
+});

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,5 +1,2 @@
-// @gauntleet/sandbox
-// Docker-based Python execution sandbox with strict isolation. Populated in
-// feat/sandbox.
-
-export {};
+export { runPython } from "./runner.js";
+export { SandboxError, type RunPythonOptions, type RunPythonResult } from "./types.js";

--- a/packages/sandbox/src/runner.ts
+++ b/packages/sandbox/src/runner.ts
@@ -1,0 +1,160 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { SandboxError, type RunPythonOptions, type RunPythonResult } from "./types.js";
+
+const DEFAULTS = {
+  timeoutMs: 5000,
+  memoryMb: 256,
+  cpus: 1,
+  pidsLimit: 64,
+  image: "gauntleet-python-runner:latest",
+};
+
+const MAX_OUTPUT_BYTES = 1_048_576; // 1 MiB cap per stream
+
+export async function runPython(opts: RunPythonOptions): Promise<RunPythonResult> {
+  const cfg = {
+    timeoutMs: opts.timeoutMs ?? DEFAULTS.timeoutMs,
+    memoryMb: opts.memoryMb ?? DEFAULTS.memoryMb,
+    cpus: opts.cpus ?? DEFAULTS.cpus,
+    pidsLimit: opts.pidsLimit ?? DEFAULTS.pidsLimit,
+    image: opts.image ?? DEFAULTS.image,
+  };
+  const containerName = `gauntleet-${randomBytes(6).toString("hex")}`;
+
+  const dockerArgs = [
+    "run",
+    "--rm",
+    "--name",
+    containerName,
+    "--network",
+    "none",
+    "--read-only",
+    "--tmpfs",
+    "/tmp:size=64m,mode=1777",
+    "--tmpfs",
+    "/sandbox:size=8m,mode=1777,uid=65534,gid=65534",
+    "--memory",
+    `${cfg.memoryMb}m`,
+    "--memory-swap",
+    `${cfg.memoryMb}m`,
+    "--cpus",
+    String(cfg.cpus),
+    "--pids-limit",
+    String(cfg.pidsLimit),
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges",
+    "--user",
+    "65534:65534",
+    "-i",
+    cfg.image,
+  ];
+
+  const start = Date.now();
+
+  return new Promise<RunPythonResult>((resolve, reject) => {
+    const child = spawn("docker", dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });
+
+    const stdoutBufs: Buffer[] = [];
+    const stderrBufs: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
+    let timedOut = false;
+    let resolved = false;
+    let killTimer: NodeJS.Timeout | null = null;
+    let spawnFailed = false;
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      const room = MAX_OUTPUT_BYTES - stdoutBytes;
+      if (room <= 0) {
+        stdoutTruncated = true;
+        return;
+      }
+      if (chunk.length > room) {
+        stdoutBufs.push(chunk.subarray(0, room));
+        stdoutBytes += room;
+        stdoutTruncated = true;
+      } else {
+        stdoutBufs.push(chunk);
+        stdoutBytes += chunk.length;
+      }
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      const room = MAX_OUTPUT_BYTES - stderrBytes;
+      if (room <= 0) {
+        stderrTruncated = true;
+        return;
+      }
+      if (chunk.length > room) {
+        stderrBufs.push(chunk.subarray(0, room));
+        stderrBytes += room;
+        stderrTruncated = true;
+      } else {
+        stderrBufs.push(chunk);
+        stderrBytes += chunk.length;
+      }
+    });
+
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      spawnFailed = true;
+      if (killTimer) clearTimeout(killTimer);
+      if (resolved) return;
+      resolved = true;
+      if (err.code === "ENOENT") {
+        reject(
+          new SandboxError(
+            "docker CLI not found on PATH — install Docker or run from a host that has it"
+          )
+        );
+        return;
+      }
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      if (killTimer) clearTimeout(killTimer);
+      if (resolved || spawnFailed) return;
+      resolved = true;
+      const stdout = Buffer.concat(stdoutBufs).toString("utf-8");
+      const stderr = Buffer.concat(stderrBufs).toString("utf-8");
+      const oom = code === 137 && !timedOut;
+      resolve({
+        stdout,
+        stderr,
+        exitCode: code,
+        durationMs: Date.now() - start,
+        timedOut,
+        oom,
+        truncated: { stdout: stdoutTruncated, stderr: stderrTruncated },
+      });
+    });
+
+    killTimer = setTimeout(() => {
+      timedOut = true;
+      const k = spawn("docker", ["kill", containerName], { stdio: "ignore" });
+      k.on("error", () => {
+        // best-effort; container may already be gone
+      });
+    }, cfg.timeoutMs);
+
+    // Pipe protocol header + code + user stdin
+    const codeBytes = Buffer.from(opts.code, "utf-8");
+    const header = Buffer.from(`GLT:${codeBytes.length}\n`, "utf-8");
+    const inputBytes = opts.stdin != null ? Buffer.from(opts.stdin, "utf-8") : Buffer.alloc(0);
+
+    child.stdin.on("error", (err: NodeJS.ErrnoException) => {
+      // EPIPE if container exits before we finish writing — not fatal here
+      if (err.code === "EPIPE") return;
+    });
+
+    child.stdin.write(header);
+    child.stdin.write(codeBytes);
+    if (inputBytes.length > 0) child.stdin.write(inputBytes);
+    child.stdin.end();
+  });
+}

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -1,0 +1,26 @@
+export interface RunPythonOptions {
+  code: string;
+  stdin?: string;
+  timeoutMs?: number;
+  memoryMb?: number;
+  cpus?: number;
+  pidsLimit?: number;
+  image?: string;
+}
+
+export interface RunPythonResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  durationMs: number;
+  timedOut: boolean;
+  oom: boolean;
+  truncated: { stdout: boolean; stderr: boolean };
+}
+
+export class SandboxError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SandboxError";
+  }
+}

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "scripts/**/*"],
   "exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,12 @@ importers:
 
   packages/sandbox:
     devDependencies:
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

Adds the execution sandbox the rest of the project will use to run untrusted user submissions. PR #3 of 8.

## What's in the box

- **`docker/python-runner/`** — minimal `python:3.12-slim` image with a tiny `runner.py` harness that reads code via a length-prefixed protocol over stdin (`GLT:<n>\n<n bytes>...`) so user code can still consume stdin for problem input.
- **`@gauntleet/sandbox` `runPython()`** — `child_process.spawn`s `docker run` with every isolation flag we need:
  - `--network=none`, `--read-only`, tmpfs `/tmp` + `/sandbox`
  - `--memory` / `--memory-swap`, `--cpus`, `--pids-limit`
  - `--cap-drop=ALL`, `--security-opt no-new-privileges`, `--user 65534:65534`
  - 1 MiB stdout/stderr cap; host-side timer issues `docker kill` if the container overruns its timeout.
- **`pnpm sandbox:build`** — builds the runner image.
- **`pnpm sandbox:smoke`** — adversarial smoke test (9 cases).
- **CI:** new `sandbox` job builds the image and runs the smoke test on every PR.

## Smoke test results (local)

```
✓ hello world (335ms)
✓ stdin pass-through (339ms)
✓ uncaught exception → non-zero exit (318ms)
✓ infinite loop times out (1614ms)
✓ fork bomb hits pid limit (3239ms)
✓ network is blocked (376ms)
✓ writes to /etc are blocked (read-only fs) (322ms)
✓ writes to /tmp are allowed (tmpfs) (339ms)
✓ memory bomb hits memory limit (372ms)
```

## Notes

- Cold-start cost is ~300ms per submission (Docker spin-up). Acceptable for MVP; if it ever becomes a problem we can reuse a long-lived container with `docker exec`. Filing as a future issue (PR #8).
- OOM detection uses the standard exit-code 137 heuristic (with `!timedOut` to avoid false positives from our own kill). Not perfect — `docker inspect` for `OOMKilled` would be authoritative — but adequate for the MVP.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [x] `pnpm build` passes
- [x] `pnpm sandbox:build` builds the image
- [x] `pnpm sandbox:smoke` — all 9 cases pass
- [x] CI green on PR (build + sandbox jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)