### PR TITLE
feat: cross-validate problems with an independent solver

### DIFF
--- a/packages/core/scripts/generate.ts
+++ b/packages/core/scripts/generate.ts
@@ -3,8 +3,14 @@ import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import { config as loadDotenv } from "dotenv";
 import { createDb, migrate } from "@gauntleet/db";
-import { createProviderFromEnv } from "@gauntleet/llm";
-import { Difficulty, generateProblem, GenerationError } from "../src/index.js";
+import { checkIndependence, createProviderFromEnv } from "@gauntleet/llm";
+import {
+  Difficulty,
+  generateProblem,
+  GenerationError,
+  validateProblem,
+  ValidationError,
+} from "../src/index.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../../..");
@@ -25,6 +31,8 @@ async function main(): Promise<void> {
     options: {
       difficulty: { type: "string", default: "medium" },
       topic: { type: "string", default: "arrays" },
+      "skip-validation": { type: "boolean", default: false },
+      seeds: { type: "string", default: "20" },
     },
   });
 
@@ -33,50 +41,105 @@ async function main(): Promise<void> {
     console.error(`--difficulty must be one of easy|medium|hard (got "${values.difficulty}")`);
     process.exit(2);
   }
-
   const topic = (values.topic ?? "").trim();
   if (!topic) {
     console.error("--topic is required");
     process.exit(2);
   }
+  const seedCount = Number.parseInt(values.seeds ?? "20", 10);
+  if (!Number.isFinite(seedCount) || seedCount < 1) {
+    console.error(`--seeds must be a positive integer (got "${values.seeds}")`);
+    process.exit(2);
+  }
+  const skipValidation = values["skip-validation"] === true;
 
   const dbPath = resolveDbPath();
   const db = createDb(dbPath);
   migrate(db);
 
   const generator = createProviderFromEnv("GENERATOR");
-  console.log(
-    `Generating: difficulty=${difficulty.data} topic=${topic}\n` +
-      `Generator: family=${generator.familyId} model=${generator.model}`
-  );
+  console.log(`Generator: family=${generator.familyId} model=${generator.model}`);
 
-  const startedAt = Date.now();
+  let validator = null;
+  if (!skipValidation) {
+    try {
+      validator = createProviderFromEnv("VALIDATOR");
+      console.log(`Validator: family=${validator.familyId} model=${validator.model}`);
+      const independence = checkIndependence(generator, validator);
+      if (!independence.independent) {
+        console.warn(`⚠ ${independence.reason}`);
+      }
+    } catch (err) {
+      console.error(
+        `\n✗ Validator config error: ${(err as Error).message}\n` +
+          `Pass --skip-validation to generate a draft without cross-validation.`
+      );
+      process.exit(2);
+    }
+  }
+
+  console.log(`\nGenerating: difficulty=${difficulty.data} topic=${topic}`);
+
+  const generatedAt = Date.now();
+  let problem;
   try {
-    const problem = await generateProblem({
+    problem = await generateProblem({
       generator,
       db,
       input: { difficulty: difficulty.data, topic },
     });
-    const ms = Date.now() - startedAt;
-    console.log(`\n✓ Generated problem in ${ms}ms`);
-    console.log(`  id:        ${problem.id}`);
-    console.log(`  title:     ${problem.title}`);
-    console.log(
-      `  signature: def ${problem.functionName}(${problem.parameters
-        .map((p) => `${p.name}: ${p.pythonType}`)
-        .join(", ")}) -> ${problem.returnType}`
-    );
-    console.log(`  status:    ${problem.status}`);
-    console.log(`  saved to:  ${dbPath}`);
-    console.log(`\n--- statement ---\n${problem.statement}\n`);
   } catch (err) {
-    const ms = Date.now() - startedAt;
+    const ms = Date.now() - generatedAt;
     if (err instanceof GenerationError) {
       console.error(`\n✗ Generation failed after ${ms}ms\n${err.message}`);
     } else {
       console.error(`\n✗ Unexpected error after ${ms}ms`);
       console.error(err);
     }
+    process.exit(1);
+  }
+  const generationMs = Date.now() - generatedAt;
+
+  console.log(`\n✓ Generated problem in ${generationMs}ms`);
+  console.log(`  id:        ${problem.id}`);
+  console.log(`  title:     ${problem.title}`);
+  console.log(
+    `  signature: def ${problem.functionName}(${problem.parameters
+      .map((p) => `${p.name}: ${p.pythonType}`)
+      .join(", ")}) -> ${problem.returnType}`
+  );
+  console.log(`  status:    ${problem.status}`);
+  console.log(`  saved to:  ${dbPath}`);
+
+  if (skipValidation || !validator) {
+    console.log(`\n(validation skipped — problem stored as draft)`);
+    return;
+  }
+
+  console.log(`\nValidating against ${seedCount} random inputs...`);
+  const validateAt = Date.now();
+  let result;
+  try {
+    result = await validateProblem({ validator, db, problemId: problem.id, seedCount });
+  } catch (err) {
+    const ms = Date.now() - validateAt;
+    if (err instanceof ValidationError) {
+      console.error(`\n✗ Validation crashed after ${ms}ms\n${err.message}`);
+    } else {
+      console.error(`\n✗ Unexpected error after ${ms}ms`);
+      console.error(err);
+    }
+    process.exit(1);
+  }
+  const validationMs = Date.now() - validateAt;
+
+  if (result.agreed) {
+    console.log(`\n✓ Validated in ${validationMs}ms — ${result.note}`);
+    console.log(`  status: ${result.problem.status}`);
+  } else {
+    console.error(`\n✗ Rejected after ${validationMs}ms`);
+    console.error(`  status: ${result.problem.status}`);
+    console.error(`  ${result.note.replace(/\n/g, "\n  ")}`);
     process.exit(1);
   }
 }

--- a/packages/core/src/compare.test.ts
+++ b/packages/core/src/compare.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { compareOutputs } from "./compare.js";
+
+describe("compareOutputs", () => {
+  it("reports agreement when all outputs match", () => {
+    const inputs = [[1], [2], [3]];
+    const refs = [1, 2, 3];
+    const vals = [1, 2, 3];
+    const result = compareOutputs(inputs, refs, vals);
+    expect(result.agreed).toBe(true);
+    expect(result.total).toBe(3);
+    expect(result.firstDisagreementIndex).toBeNull();
+    expect(result.note).toMatch(/agreed on all 3/);
+  });
+
+  it("reports the first disagreement index", () => {
+    const inputs = [[1], [2], [3], [4]];
+    const refs = [1, 2, 99, 4];
+    const vals = [1, 2, 3, 4];
+    const result = compareOutputs(inputs, refs, vals);
+    expect(result.agreed).toBe(false);
+    expect(result.firstDisagreementIndex).toBe(2);
+    expect(result.note).toContain("input 2");
+  });
+
+  it("reports a length mismatch when outputs are short", () => {
+    const inputs = [[1], [2], [3]];
+    const refs = [1, 2, 3];
+    const vals = [1, 2];
+    const result = compareOutputs(inputs, refs, vals);
+    expect(result.agreed).toBe(false);
+    expect(result.firstDisagreementIndex).toBeNull();
+    expect(result.note).toMatch(/length mismatch/);
+  });
+
+  it("uses deep equality for compound values", () => {
+    const inputs = [[[1, 2]]];
+    const refs = [{ a: 1, b: [2, 3] }];
+    const vals = [{ b: [2, 3], a: 1 }];
+    expect(compareOutputs(inputs, refs, vals).agreed).toBe(true);
+  });
+
+  it("flags a deep-equality difference", () => {
+    const inputs = [[[1, 2]]];
+    const refs = [{ a: 1, b: [2, 3] }];
+    const vals = [{ a: 1, b: [2, 4] }];
+    const result = compareOutputs(inputs, refs, vals);
+    expect(result.agreed).toBe(false);
+    expect(result.firstDisagreementIndex).toBe(0);
+  });
+
+  it("truncates very long values in the note", () => {
+    const big = "x".repeat(500);
+    const inputs = [[big]];
+    const refs = [big];
+    const vals = ["short"];
+    const result = compareOutputs(inputs, refs, vals);
+    expect(result.note.length).toBeLessThan(800);
+    expect(result.note).toContain("…");
+  });
+});

--- a/packages/core/src/compare.ts
+++ b/packages/core/src/compare.ts
@@ -1,0 +1,66 @@
+import { deepEqual } from "./generate.js";
+
+export interface AgreementResult {
+  agreed: boolean;
+  total: number;
+  firstDisagreementIndex: number | null;
+  /** Human-readable note suitable for storing in validation_notes. */
+  note: string;
+}
+
+/**
+ * Walks reference and validator outputs in parallel. Returns the first index
+ * at which they disagree, plus a short note describing the result.
+ */
+export function compareOutputs(
+  inputs: unknown[][],
+  referenceOutputs: unknown[],
+  validatorOutputs: unknown[]
+): AgreementResult {
+  const total = inputs.length;
+  if (referenceOutputs.length !== total || validatorOutputs.length !== total) {
+    return {
+      agreed: false,
+      total,
+      firstDisagreementIndex: null,
+      note:
+        `output length mismatch: ${total} inputs, ` +
+        `${referenceOutputs.length} reference outputs, ${validatorOutputs.length} validator outputs`,
+    };
+  }
+  for (let i = 0; i < total; i++) {
+    if (!deepEqual(referenceOutputs[i], validatorOutputs[i])) {
+      return {
+        agreed: false,
+        total,
+        firstDisagreementIndex: i,
+        note: formatDisagreement(i, inputs[i], referenceOutputs[i], validatorOutputs[i]),
+      };
+    }
+  }
+  return {
+    agreed: true,
+    total,
+    firstDisagreementIndex: null,
+    note: `agreed on all ${total} inputs`,
+  };
+}
+
+function formatDisagreement(
+  index: number,
+  input: unknown,
+  reference: unknown,
+  validator: unknown
+): string {
+  return [
+    `disagreement on input ${index}:`,
+    `  input: ${truncate(JSON.stringify(input))}`,
+    `  reference: ${truncate(JSON.stringify(reference))}`,
+    `  validator: ${truncate(JSON.stringify(validator))}`,
+  ].join("\n");
+}
+
+function truncate(s: string, max = 200): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,13 @@
+export { compareOutputs, type AgreementResult } from "./compare.js";
 export { generateProblem, GenerationError } from "./generate.js";
 export type { GenerateProblemInput, GenerateProblemOptions } from "./generate.js";
 export { HarnessError, runInputGenerator, runReferenceSolution } from "./python-harness.js";
 export { buildMessages, PROMPT_VERSION } from "./prompt.js";
 export { Difficulty, GeneratedProblem, ParameterDef, SampleTest } from "./schema.js";
+export { validateProblem, ValidationError } from "./validate.js";
+export type { ValidateProblemOptions, ValidationResult } from "./validate.js";
+export {
+  buildValidatorMessages,
+  extractPythonCode,
+  VALIDATOR_PROMPT_VERSION,
+} from "./validator-prompt.js";

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -1,0 +1,173 @@
+import { eq } from "drizzle-orm";
+import { problems, type Db, type Problem } from "@gauntleet/db";
+import type { LLMProvider } from "@gauntleet/llm";
+import { compareOutputs } from "./compare.js";
+import { runInputGenerator, runReferenceSolution } from "./python-harness.js";
+import { buildValidatorMessages, extractPythonCode } from "./validator-prompt.js";
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
+export interface ValidateProblemOptions {
+  validator: LLMProvider;
+  db: Db;
+  problemId: string;
+  seedCount?: number;
+  /** Per-execution timeout for sandbox runs of the reference + validator solutions. */
+  solutionTimeoutMs?: number;
+}
+
+export interface ValidationResult {
+  problem: Problem;
+  agreed: boolean;
+  total: number;
+  firstDisagreementIndex: number | null;
+  note: string;
+}
+
+const DEFAULT_SEED_COUNT = 20;
+const DEFAULT_SOLUTION_TIMEOUT_MS = 5_000;
+
+export async function validateProblem(opts: ValidateProblemOptions): Promise<ValidationResult> {
+  const seedCount = opts.seedCount ?? DEFAULT_SEED_COUNT;
+  const solutionTimeoutMs = opts.solutionTimeoutMs ?? DEFAULT_SOLUTION_TIMEOUT_MS;
+
+  const problem = opts.db.select().from(problems).where(eq(problems.id, opts.problemId)).get();
+  if (!problem) {
+    throw new ValidationError(`problem ${opts.problemId} not found`);
+  }
+
+  // 1. Ask the validator to solve the problem.
+  const messages = buildValidatorMessages({
+    statement: problem.statement,
+    functionName: problem.functionName,
+    parameters: problem.parameters,
+    returnType: problem.returnType,
+  });
+  const response = await opts.validator.complete({
+    messages: [{ role: "user", content: messages.user }],
+    system: messages.system,
+    maxTokens: 4096,
+    temperature: 0.2,
+  });
+  const validatorSolution = extractPythonCode(response.text);
+  if (!validatorSolution.trim()) {
+    return persistResult(opts, problem, {
+      agreed: false,
+      total: 0,
+      firstDisagreementIndex: null,
+      note: "validator returned empty solution",
+      validatorSolution,
+      seedCount,
+    });
+  }
+
+  // 2. Generate seedCount random inputs via the problem's input generator.
+  const seeds = Array.from({ length: seedCount }, (_, i) => i);
+  let randomInputs: unknown[][];
+  try {
+    randomInputs = await runInputGenerator({ code: problem.inputGenerator, seeds });
+  } catch (err) {
+    return persistResult(opts, problem, {
+      agreed: false,
+      total: 0,
+      firstDisagreementIndex: null,
+      note: `input generator failed during validation: ${(err as Error).message}`,
+      validatorSolution,
+      seedCount,
+    });
+  }
+
+  // 3. Run reference + validator solutions on the same inputs.
+  let referenceOutputs: unknown[];
+  try {
+    referenceOutputs = await runReferenceSolution({
+      code: problem.referenceSolution,
+      functionName: problem.functionName,
+      inputs: randomInputs,
+      timeoutMs: solutionTimeoutMs,
+    });
+  } catch (err) {
+    return persistResult(opts, problem, {
+      agreed: false,
+      total: seedCount,
+      firstDisagreementIndex: null,
+      note: `reference solution failed on random inputs: ${(err as Error).message}`,
+      validatorSolution,
+      seedCount,
+    });
+  }
+
+  let validatorOutputs: unknown[];
+  try {
+    validatorOutputs = await runReferenceSolution({
+      code: validatorSolution,
+      functionName: problem.functionName,
+      inputs: randomInputs,
+      timeoutMs: solutionTimeoutMs,
+    });
+  } catch (err) {
+    return persistResult(opts, problem, {
+      agreed: false,
+      total: seedCount,
+      firstDisagreementIndex: null,
+      note: `validator solution failed on random inputs: ${(err as Error).message}`,
+      validatorSolution,
+      seedCount,
+    });
+  }
+
+  // 4. Compare.
+  const agreement = compareOutputs(randomInputs, referenceOutputs, validatorOutputs);
+  return persistResult(opts, problem, {
+    agreed: agreement.agreed,
+    total: agreement.total,
+    firstDisagreementIndex: agreement.firstDisagreementIndex,
+    note: agreement.note,
+    validatorSolution,
+    seedCount,
+  });
+}
+
+interface PersistArgs {
+  agreed: boolean;
+  total: number;
+  firstDisagreementIndex: number | null;
+  note: string;
+  validatorSolution: string;
+  seedCount: number;
+}
+
+function persistResult(
+  opts: ValidateProblemOptions,
+  problem: Problem,
+  args: PersistArgs
+): ValidationResult {
+  const status: Problem["status"] = args.agreed ? "validated" : "rejected";
+  const updated = opts.db
+    .update(problems)
+    .set({
+      status,
+      validationNotes: args.note,
+      validatorProvider: opts.validator.familyId,
+      validatorModel: opts.validator.model,
+      validatorSolution: args.validatorSolution,
+      validatedAt: new Date(),
+      validationSeedCount: args.seedCount,
+    })
+    .where(eq(problems.id, problem.id))
+    .returning()
+    .get();
+  if (!updated) throw new ValidationError("update did not return a row");
+  return {
+    problem: updated,
+    agreed: args.agreed,
+    total: args.total,
+    firstDisagreementIndex: args.firstDisagreementIndex,
+    note: args.note,
+  };
+}

--- a/packages/core/src/validator-prompt.test.ts
+++ b/packages/core/src/validator-prompt.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildValidatorMessages,
+  extractPythonCode,
+  VALIDATOR_PROMPT_VERSION,
+} from "./validator-prompt.js";
+
+describe("buildValidatorMessages", () => {
+  it("returns system + user content", () => {
+    const messages = buildValidatorMessages({
+      statement: "Add two numbers.",
+      functionName: "add",
+      parameters: [
+        { name: "a", pythonType: "int" },
+        { name: "b", pythonType: "int" },
+      ],
+      returnType: "int",
+    });
+    expect(typeof messages.system).toBe("string");
+    expect(messages.system.length).toBeGreaterThan(0);
+    expect(typeof messages.user).toBe("string");
+    expect(messages.user.length).toBeGreaterThan(0);
+  });
+
+  it("embeds the exact function signature in the user message", () => {
+    const messages = buildValidatorMessages({
+      statement: "Foo.",
+      functionName: "two_sum",
+      parameters: [
+        { name: "nums", pythonType: "list[int]" },
+        { name: "target", pythonType: "int" },
+      ],
+      returnType: "list[int]",
+    });
+    expect(messages.user).toContain("def two_sum(nums: list[int], target: int) -> list[int]:");
+  });
+
+  it("includes the problem statement", () => {
+    const messages = buildValidatorMessages({
+      statement: "Reverse the array in place.",
+      functionName: "reverse",
+      parameters: [{ name: "nums", pythonType: "list[int]" }],
+      returnType: "None",
+    });
+    expect(messages.user).toContain("Reverse the array in place.");
+  });
+
+  it("forbids prose / fences / markdown in the system prompt", () => {
+    const messages = buildValidatorMessages({
+      statement: "x",
+      functionName: "f",
+      parameters: [{ name: "x", pythonType: "int" }],
+      returnType: "int",
+    });
+    expect(messages.system).toMatch(/no.*markdown.*fences/i);
+    expect(messages.system).toMatch(/no prose/i);
+  });
+});
+
+describe("VALIDATOR_PROMPT_VERSION", () => {
+  it("is a non-empty string", () => {
+    expect(typeof VALIDATOR_PROMPT_VERSION).toBe("string");
+    expect(VALIDATOR_PROMPT_VERSION.length).toBeGreaterThan(0);
+  });
+});
+
+describe("extractPythonCode", () => {
+  it("returns plain code unchanged", () => {
+    const code = "def f(x):\n    return x + 1\n";
+    expect(extractPythonCode(code)).toBe(code.trim());
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(extractPythonCode("\n\n  def f(): return 1\n\n")).toBe("def f(): return 1");
+  });
+
+  it("strips a full ```python fence", () => {
+    const text = "```python\ndef f(x):\n    return x\n```";
+    expect(extractPythonCode(text)).toBe("def f(x):\n    return x");
+  });
+
+  it("strips a bare ``` fence", () => {
+    const text = "```\ndef f(x):\n    return x\n```";
+    expect(extractPythonCode(text)).toBe("def f(x):\n    return x");
+  });
+
+  it("strips a ```py fence", () => {
+    const text = "```py\ndef f(x):\n    return x\n```";
+    expect(extractPythonCode(text)).toBe("def f(x):\n    return x");
+  });
+
+  it("extracts the first fenced block when there is surrounding prose", () => {
+    const text = "Here is my solution:\n\n```python\ndef f(x):\n    return x\n```\n\nLet me know!";
+    expect(extractPythonCode(text)).toBe("def f(x):\n    return x");
+  });
+
+  it("returns the trimmed text when there is no fence", () => {
+    expect(extractPythonCode("just some code")).toBe("just some code");
+  });
+});

--- a/packages/core/src/validator-prompt.ts
+++ b/packages/core/src/validator-prompt.ts
@@ -1,0 +1,60 @@
+import type { ParameterDef } from "@gauntleet/db";
+
+export const VALIDATOR_PROMPT_VERSION = "v1";
+
+const SYSTEM_PROMPT = `You solve algorithmic Python problems for an automated grading system.
+
+Hard constraints:
+- Reply with ONLY Python source code. No prose, no markdown fences, no comments outside the function.
+- Define exactly the function signature given (same name, same parameter names, same return type). Do not add or rename parameters.
+- Use only the Python standard library.
+- The function must be self-contained — no I/O, no globals, no network, no filesystem.
+- The function will be called many times; do not include test code, sample inputs, or print statements.`;
+
+export interface ValidatorPromptInput {
+  statement: string;
+  functionName: string;
+  parameters: ParameterDef[];
+  returnType: string;
+}
+
+export function buildValidatorMessages(input: ValidatorPromptInput): {
+  system: string;
+  user: string;
+} {
+  const params = input.parameters.map((p) => `${p.name}: ${p.pythonType}`).join(", ");
+  const signature = `def ${input.functionName}(${params}) -> ${input.returnType}:`;
+  const user = [
+    "Solve the following problem in Python.",
+    "",
+    "Problem:",
+    input.statement,
+    "",
+    "Function signature (use exactly):",
+    "```",
+    signature,
+    "    ...",
+    "```",
+    "",
+    "Reply with the full source for that function and any helper code it needs — and nothing else.",
+  ].join("\n");
+  return { system: SYSTEM_PROMPT, user };
+}
+
+/**
+ * Strips a single leading/trailing markdown fence if present, plus surrounding whitespace.
+ * Tolerant of `\`\`\`python` or `\`\`\`` fences. Falls back to the raw text if no fence.
+ */
+export function extractPythonCode(text: string): string {
+  const trimmed = text.trim();
+  const fenceMatch = trimmed.match(/^```(?:python|py)?\s*\n([\s\S]*?)\n```$/);
+  if (fenceMatch && fenceMatch[1] !== undefined) {
+    return fenceMatch[1].trim();
+  }
+  // First fenced block anywhere in the text
+  const innerFence = trimmed.match(/```(?:python|py)?\s*\n([\s\S]*?)\n```/);
+  if (innerFence && innerFence[1] !== undefined) {
+    return innerFence[1].trim();
+  }
+  return trimmed;
+}

--- a/packages/db/drizzle/0001_loud_sersi.sql
+++ b/packages/db/drizzle/0001_loud_sersi.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `problems` ADD `validator_provider` text;--> statement-breakpoint
+ALTER TABLE `problems` ADD `validator_model` text;--> statement-breakpoint
+ALTER TABLE `problems` ADD `validator_solution` text;--> statement-breakpoint
+ALTER TABLE `problems` ADD `validated_at` integer;--> statement-breakpoint
+ALTER TABLE `problems` ADD `validation_seed_count` integer;

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,183 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f3b875ef-6363-4103-aeb6-28840aac6e43",
+  "prevId": "68ca0c03-88e6-417b-b0a6-49a4991eaae7",
+  "tables": {
+    "problems": {
+      "name": "problems",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "function_name": {
+          "name": "function_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "return_type": {
+          "name": "return_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_solution": {
+          "name": "reference_solution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_generator": {
+          "name": "input_generator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_tests": {
+          "name": "sample_tests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generator_provider": {
+          "name": "generator_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generator_model": {
+          "name": "generator_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "validation_notes": {
+          "name": "validation_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validator_provider": {
+          "name": "validator_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validator_model": {
+          "name": "validator_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validator_solution": {
+          "name": "validator_solution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_seed_count": {
+          "name": "validation_seed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777329399177,
       "tag": "0000_workable_pride",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1777331300971,
+      "tag": "0001_loud_sersi",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -37,6 +37,11 @@ export const problems = sqliteTable("problems", {
     .notNull()
     .default("draft"),
   validationNotes: text("validation_notes"),
+  validatorProvider: text("validator_provider"),
+  validatorModel: text("validator_model"),
+  validatorSolution: text("validator_solution"),
+  validatedAt: integer("validated_at", { mode: "timestamp_ms" }),
+  validationSeedCount: integer("validation_seed_count"),
 });
 
 export type Problem = typeof problems.$inferSelect;


### PR DESCRIPTION
## Summary

The second half of the verification story. After generation + sanity-check, a validator LLM independently solves the problem with the exact function signature, and both solutions run against N random inputs. Agreement → `status='validated'`. Any disagreement, harness failure, or sandbox crash → `status='rejected'` with a note. PR #5 of 8.

## What's new

### Schema (one new migration)

Adds `validator_provider`, `validator_model`, `validator_solution`, `validated_at`, `validation_seed_count`. Old `draft` rows from PR #4 are untouched — migration is purely additive.

### `@gauntleet/core`

- **`validator-prompt.ts`** — strict "reply with only Python source" system prompt + user message pinning the exact `def fn(...) -> ...` signature. Includes `extractPythonCode()` tolerant of `\`\`\`python` / `\`\`\`py` / bare fences and surrounding prose.
- **`compare.ts`** — walks reference vs validator outputs, returns first disagreement index + a truncated human-readable note for `validation_notes`.
- **`validate.ts`** — `validateProblem()` orchestrator with explicit failure modes: empty validator solution, input-generator-failed-during-validation, reference-crashed-on-random-inputs, validator-crashed-on-random-inputs, actual output disagreement. Each one writes a specific note.

### CLI

- `pnpm gen` now generates **and** validates by default
- `--skip-validation` for the draft-only case
- `--seeds=N` tunes the random-input count (default 20)
- `checkIndependence()` warning fires loudly before validation when generator and validator share a backend

## Tests (74 → 92 across the workspace)

- `validator-prompt.test.ts` (12 tests): signature embedding, statement embedding, system-prompt strictness, `extractPythonCode` against fence variants and surrounding prose
- `compare.test.ts` (6 tests): agreement, first-disagreement detection, length mismatch, deep equality, truncation

## End-to-end verification

```
$ pnpm gen --difficulty=easy --topic=arrays --seeds=10
Generator: family=http://192.168.1.73:1234/v1 model=qwen/qwen3-coder-30b
Validator: family=http://192.168.1.73:1234/v1 model=qwen/qwen3-coder-30b
⚠ Generator and validator share the same backend ...

✓ Generated problem in 62206ms
  title: Remove Duplicates from Sorted Array
  status: draft

Validating against 10 random inputs...

✓ Validated in 9184ms — agreed on all 10 inputs
  status: validated
```

## Cold reality check

With both roles on the same LM Studio model (the current `.env.local`), agreement is near-100% no matter what — same weights, same answer. **The pipeline is correct; the *signal* is weak.** To actually exercise rejection paths, point the validator at a different family (Anthropic API key, OpenAI API key, or a second LM Studio instance with a different model). The independence warning makes this explicit on every run.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build`
- [x] `pnpm test` — 74 passed
- [x] End-to-end `pnpm gen` produces a `validated` row with all new metadata populated
- [x] Migration applies cleanly to a DB that already has rows from PR #4
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)