### PR TITLE
Settings page (model overrides, sandbox limits, env snapshot)

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -12,14 +12,27 @@ import {
   ValidationError,
   type GradeResult,
 } from "@gauntleet/core";
-import { checkIndependence, createProviderFromEnv } from "@gauntleet/llm";
+import { checkIndependence, createProvider, type LLMProvider, type Role } from "@gauntleet/llm";
 import { ensureEnv } from "../lib/env";
 import { getDb, getProblem } from "../lib/db";
 import { parseGenerateInput } from "../lib/parse-input";
+import { getSettings, resolveProviderConfig, updateSettings } from "../lib/settings";
+import type { ProviderOverrides, UserSettings } from "../lib/settings-core";
+import { isTopic, TOPICS } from "@gauntleet/core/topics";
 
 export interface GenerateState {
   status: "idle" | "error";
   message: string;
+}
+
+function buildProvider(role: Role, settings: UserSettings): LLMProvider | { error: string } {
+  const config = resolveProviderConfig(role, settings, process.env);
+  if ("error" in config) return config;
+  try {
+    return createProvider(config);
+  } catch (err) {
+    return { error: (err as Error).message };
+  }
 }
 
 export async function generateNewProblem(
@@ -36,14 +49,15 @@ export async function generateNewProblem(
   }
 
   const db = getDb();
+  const settings = getSettings(db);
 
-  let generator;
-  let validator;
-  try {
-    generator = createProviderFromEnv("GENERATOR");
-    validator = createProviderFromEnv("VALIDATOR");
-  } catch (err) {
-    return { status: "error", message: `Provider config error: ${(err as Error).message}` };
+  const generator = buildProvider("GENERATOR", settings);
+  if ("error" in generator) {
+    return { status: "error", message: `Generator config error: ${generator.error}` };
+  }
+  const validator = buildProvider("VALIDATOR", settings);
+  if ("error" in validator) {
+    return { status: "error", message: `Validator config error: ${validator.error}` };
   }
 
   const independence = checkIndependence(generator, validator);
@@ -63,7 +77,13 @@ export async function generateNewProblem(
   }
 
   try {
-    await validateProblem({ validator, db, problemId, seedCount: 20 });
+    await validateProblem({
+      validator,
+      db,
+      problemId,
+      seedCount: 20,
+      solutionTimeoutMs: settings.sandboxTimeoutMs,
+    });
   } catch (err) {
     if (err instanceof ValidationError) {
       return { status: "error", message: `Validation crashed: ${err.message}` };
@@ -95,8 +115,14 @@ export async function runUserCodeAction(problemId: string, code: string): Promis
   const problem = getProblem(problemId);
   if (!problem) return { ok: false, error: "problem not found" };
 
+  const settings = getSettings();
   try {
-    const grade = await runAgainstSamples({ problem, code: codeCheck.code });
+    const grade = await runAgainstSamples({
+      problem,
+      code: codeCheck.code,
+      timeoutMs: settings.sandboxTimeoutMs,
+      memoryMb: settings.sandboxMemoryMb,
+    });
     return { ok: true, grade };
   } catch (err) {
     return { ok: false, error: `run failed: ${(err as Error).message}` };
@@ -115,8 +141,15 @@ export async function submitUserCodeAction(
   if (!problem) return { ok: false, error: "problem not found" };
 
   const db = getDb();
+  const settings = getSettings(db);
   try {
-    const { grade } = await gradeSubmission({ db, problemId, code: codeCheck.code });
+    const { grade } = await gradeSubmission({
+      db,
+      problemId,
+      code: codeCheck.code,
+      timeoutMs: settings.sandboxTimeoutMs,
+      memoryMb: settings.sandboxMemoryMb,
+    });
     revalidatePath(`/p/${problemId}`);
     return { ok: true, grade };
   } catch (err) {
@@ -125,4 +158,98 @@ export async function submitUserCodeAction(
     }
     throw err;
   }
+}
+
+export interface SaveSettingsResult {
+  ok: boolean;
+  message: string;
+}
+
+export async function saveSettingsAction(
+  _prevState: SaveSettingsResult,
+  formData: FormData
+): Promise<SaveSettingsResult> {
+  ensureEnv();
+  const parsed = parseSettingsForm(formData);
+  if (!parsed.ok) return { ok: false, message: parsed.error };
+  try {
+    updateSettings(getDb(), parsed.value);
+  } catch (err) {
+    return { ok: false, message: (err as Error).message };
+  }
+  revalidatePath("/settings");
+  revalidatePath("/");
+  return { ok: true, message: "Settings saved." };
+}
+
+interface ParsedSettingsForm {
+  defaultDifficulty: UserSettings["defaultDifficulty"];
+  defaultTopic: UserSettings["defaultTopic"];
+  generator: ProviderOverrides;
+  validator: ProviderOverrides;
+  sandboxTimeoutMs: number;
+  sandboxMemoryMb: number;
+}
+
+function parseSettingsForm(
+  fd: FormData
+): { ok: true; value: ParsedSettingsForm } | { ok: false; error: string } {
+  const difficultyRaw = String(fd.get("default_difficulty") ?? "");
+  const difficulty: UserSettings["defaultDifficulty"] =
+    difficultyRaw === "easy" || difficultyRaw === "medium" || difficultyRaw === "hard"
+      ? difficultyRaw
+      : null;
+
+  const topicRaw = String(fd.get("default_topic") ?? "");
+  const topic: UserSettings["defaultTopic"] =
+    topicRaw === "" ? null : isTopic(topicRaw) ? topicRaw : null;
+  if (topicRaw !== "" && !isTopic(topicRaw)) {
+    return { ok: false, error: `default topic "${topicRaw}" is not in the supported set` };
+  }
+
+  const generator = parseProviderForm(fd, "generator");
+  const validator = parseProviderForm(fd, "validator");
+
+  const timeoutRaw = String(fd.get("sandbox_timeout_ms") ?? "");
+  const timeout = parseInt(timeoutRaw, 10);
+  if (!Number.isFinite(timeout) || timeout < 100 || timeout > 60_000) {
+    return { ok: false, error: "sandbox timeout must be between 100 and 60000 ms" };
+  }
+
+  const memoryRaw = String(fd.get("sandbox_memory_mb") ?? "");
+  const memory = parseInt(memoryRaw, 10);
+  if (!Number.isFinite(memory) || memory < 32 || memory > 4096) {
+    return { ok: false, error: "sandbox memory must be between 32 and 4096 MB" };
+  }
+
+  // Touch TOPICS so it's referenced (we re-validate at the page boundary too).
+  void TOPICS;
+
+  return {
+    ok: true,
+    value: {
+      defaultDifficulty: difficulty,
+      defaultTopic: topic,
+      generator,
+      validator,
+      sandboxTimeoutMs: timeout,
+      sandboxMemoryMb: memory,
+    },
+  };
+}
+
+const PRESET_VALUES = ["anthropic", "openai", "lmstudio", "ollama", "custom"] as const;
+
+function parseProviderForm(fd: FormData, role: "generator" | "validator"): ProviderOverrides {
+  const presetRaw = String(fd.get(`${role}_preset`) ?? "").toLowerCase();
+  const preset = (PRESET_VALUES as readonly string[]).includes(presetRaw)
+    ? (presetRaw as (typeof PRESET_VALUES)[number])
+    : null;
+  const model = String(fd.get(`${role}_model`) ?? "").trim();
+  const baseUrl = String(fd.get(`${role}_base_url`) ?? "").trim();
+  return {
+    preset,
+    model: model.length > 0 ? model : null,
+    baseUrl: baseUrl.length > 0 ? baseUrl : null,
+  };
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,6 +7,7 @@ import { ProblemFilters } from "../components/ProblemFilters";
 import { StatusIcon } from "../components/StatusIcon";
 import { listAllTopics, listProblemsWithStats, type ProblemWithStats } from "../lib/db";
 import { acceptanceRate, deriveStatus, type ProblemUserStatus } from "../lib/problem-status";
+import { getSettings } from "../lib/settings";
 
 export const dynamic = "force-dynamic";
 
@@ -34,6 +35,7 @@ export default async function Home({ searchParams }: { searchParams: Promise<Hom
     return deriveStatus(p) === statusFilter;
   });
 
+  const userSettings = getSettings();
   const topicsInUse = listAllTopics().filter((t): t is Topic => isTopic(t));
   // Show every supported topic in the filter, ordered with in-use ones first.
   const topicSet = new Set(topicsInUse);
@@ -55,7 +57,15 @@ export default async function Home({ searchParams }: { searchParams: Promise<Hom
 
         <section className="mb-12">
           <SectionHeader>Generate a new problem</SectionHeader>
-          <GenerateForm />
+          <GenerateForm
+            {...(userSettings.defaultDifficulty && {
+              defaultDifficulty: userSettings.defaultDifficulty,
+            })}
+            {...(userSettings.defaultTopic &&
+              isTopic(userSettings.defaultTopic) && {
+                defaultTopic: userSettings.defaultTopic,
+              })}
+          />
         </section>
 
         <section>

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,34 +1,36 @@
-import { Settings } from "lucide-react";
+import { Settings as SettingsIcon } from "lucide-react";
+import { SettingsForm } from "../../components/SettingsForm";
+import { ensureEnv } from "../../lib/env";
+import { getSettings, snapshotEnv } from "../../lib/settings";
+
+export const dynamic = "force-dynamic";
 
 export default function SettingsPage() {
+  ensureEnv();
+  const settings = getSettings();
+  const envSnapshot = snapshotEnv(process.env);
+
   return (
     <main className="flex-1 overflow-y-auto">
       <div className="mx-auto max-w-3xl px-6 py-10">
-        <div className="mb-6 flex items-center gap-3">
+        <div className="mb-8 flex items-center gap-3">
           <span className="grid h-9 w-9 place-items-center rounded-lg bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300">
-            <Settings className="h-5 w-5" />
+            <SettingsIcon className="h-5 w-5" />
           </span>
           <div>
             <h1 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-50">
               Settings
             </h1>
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Tweak how Gauntleet runs on this machine.
+              Tweak how Gauntleet runs on this machine. Overrides win over{" "}
+              <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-[11px] dark:bg-slate-800">
+                .env.local
+              </code>
+              .
             </p>
           </div>
         </div>
-        <div className="rounded-xl border border-dashed border-slate-300 bg-white px-6 py-12 text-center dark:border-slate-700 dark:bg-slate-900/40">
-          <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
-            Coming in the next PR.
-          </p>
-          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-            Default difficulty + topic, model overrides, sandbox limits, and a read-only
-            <code className="mx-1 rounded bg-slate-100 px-1 py-0.5 font-mono text-[11px] dark:bg-slate-800">
-              .env.local
-            </code>{" "}
-            preview.
-          </p>
-        </div>
+        <SettingsForm settings={settings} envSnapshot={envSnapshot} />
       </div>
     </main>
   );

--- a/apps/web/components/GenerateForm.tsx
+++ b/apps/web/components/GenerateForm.tsx
@@ -3,12 +3,20 @@
 import { useActionState } from "react";
 import { useFormStatus } from "react-dom";
 import { Loader2, Sparkles } from "lucide-react";
-import { TOPICS, topicLabel } from "@gauntleet/core/topics";
+import { TOPICS, topicLabel, type Topic } from "@gauntleet/core/topics";
 import { generateNewProblem, type GenerateState } from "../app/actions";
 
 const INITIAL_STATE: GenerateState = { status: "idle", message: "" };
 
-export function GenerateForm() {
+interface GenerateFormProps {
+  defaultDifficulty?: "easy" | "medium" | "hard";
+  defaultTopic?: Topic;
+}
+
+export function GenerateForm({
+  defaultDifficulty = "medium",
+  defaultTopic = "arrays",
+}: GenerateFormProps = {}) {
   const [state, formAction] = useActionState(generateNewProblem, INITIAL_STATE);
 
   return (
@@ -18,14 +26,19 @@ export function GenerateForm() {
     >
       <div className="grid grid-cols-1 gap-4 md:grid-cols-[10rem_1fr_auto] md:items-end">
         <Field label="Difficulty" htmlFor="difficulty">
-          <select id="difficulty" name="difficulty" defaultValue="medium" className={selectStyles}>
+          <select
+            id="difficulty"
+            name="difficulty"
+            defaultValue={defaultDifficulty}
+            className={selectStyles}
+          >
             <option value="easy">Easy</option>
             <option value="medium">Medium</option>
             <option value="hard">Hard</option>
           </select>
         </Field>
         <Field label="Topic" htmlFor="topic">
-          <select id="topic" name="topic" defaultValue="arrays" className={selectStyles}>
+          <select id="topic" name="topic" defaultValue={defaultTopic} className={selectStyles}>
             {TOPICS.map((t) => (
               <option key={t} value={t}>
                 {topicLabel(t)}

--- a/apps/web/components/SettingsForm.tsx
+++ b/apps/web/components/SettingsForm.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { CheckCircle2, Loader2, Save, XCircle } from "lucide-react";
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { TOPICS, topicLabel } from "@gauntleet/core/topics";
+import { saveSettingsAction, type SaveSettingsResult } from "../app/actions";
+import type { EnvSnapshot, UserSettings } from "../lib/settings-core";
+
+const PRESETS = ["anthropic", "openai", "lmstudio", "ollama", "custom"] as const;
+type Preset = (typeof PRESETS)[number];
+
+const INITIAL: SaveSettingsResult = { ok: false, message: "" };
+
+interface SettingsFormProps {
+  settings: UserSettings;
+  envSnapshot: EnvSnapshot;
+}
+
+export function SettingsForm({ settings, envSnapshot }: SettingsFormProps) {
+  const [state, formAction] = useActionState(saveSettingsAction, INITIAL);
+
+  return (
+    <form action={formAction} className="space-y-8">
+      <Section title="Defaults" description="What the Generate form starts with on the home page.">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Field label="Default difficulty" htmlFor="default_difficulty">
+            <select
+              id="default_difficulty"
+              name="default_difficulty"
+              defaultValue={settings.defaultDifficulty ?? ""}
+              className={selectStyles}
+            >
+              <option value="">No default (choose each time)</option>
+              <option value="easy">Easy</option>
+              <option value="medium">Medium</option>
+              <option value="hard">Hard</option>
+            </select>
+          </Field>
+          <Field label="Default topic" htmlFor="default_topic">
+            <select
+              id="default_topic"
+              name="default_topic"
+              defaultValue={settings.defaultTopic ?? ""}
+              className={selectStyles}
+            >
+              <option value="">No default (choose each time)</option>
+              {TOPICS.map((t) => (
+                <option key={t} value={t}>
+                  {topicLabel(t)}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+      </Section>
+
+      <Section
+        title="Generator model"
+        description="Used to write new problems. Leave blank to use the .env.local value."
+      >
+        <ProviderFields
+          role="generator"
+          overrides={settings.generator}
+          envProvider={envSnapshot.generator.provider}
+          envModel={envSnapshot.generator.model}
+          envBaseUrl={envSnapshot.generator.baseUrl}
+        />
+      </Section>
+
+      <Section
+        title="Validator model"
+        description="Independently solves each problem to cross-check the generator. Should ideally be a different model family."
+      >
+        <ProviderFields
+          role="validator"
+          overrides={settings.validator}
+          envProvider={envSnapshot.validator.provider}
+          envModel={envSnapshot.validator.model}
+          envBaseUrl={envSnapshot.validator.baseUrl}
+        />
+      </Section>
+
+      <Section
+        title="Sandbox limits"
+        description="Applied to every Run, Submit, and validation execution."
+      >
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Field label="Timeout (ms)" htmlFor="sandbox_timeout_ms">
+            <input
+              type="number"
+              id="sandbox_timeout_ms"
+              name="sandbox_timeout_ms"
+              defaultValue={settings.sandboxTimeoutMs}
+              min={100}
+              max={60000}
+              step={100}
+              className={inputStyles}
+            />
+          </Field>
+          <Field label="Memory (MB)" htmlFor="sandbox_memory_mb">
+            <input
+              type="number"
+              id="sandbox_memory_mb"
+              name="sandbox_memory_mb"
+              defaultValue={settings.sandboxMemoryMb}
+              min={32}
+              max={4096}
+              step={32}
+              className={inputStyles}
+            />
+          </Field>
+        </div>
+      </Section>
+
+      <Section
+        title=".env.local snapshot"
+        description="What the running process sees from the .env.local file. Read-only — edit the file and restart to change."
+      >
+        <EnvPanel snapshot={envSnapshot} />
+      </Section>
+
+      <div className="flex items-center justify-between gap-4 border-t border-slate-200 pt-5 dark:border-slate-800">
+        {state.message ? (
+          state.ok ? (
+            <span className="inline-flex items-center gap-1.5 text-sm text-emerald-600 dark:text-emerald-400">
+              <CheckCircle2 className="h-4 w-4" />
+              {state.message}
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 text-sm text-rose-600 dark:text-rose-400">
+              <XCircle className="h-4 w-4" />
+              {state.message}
+            </span>
+          )
+        ) : (
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            Settings persist in <code className="font-mono">data/gauntleet.db</code>.
+          </span>
+        )}
+        <SaveButton />
+      </div>
+    </form>
+  );
+}
+
+function ProviderFields({
+  role,
+  overrides,
+  envProvider,
+  envModel,
+  envBaseUrl,
+}: {
+  role: "generator" | "validator";
+  overrides: { preset: Preset | null; model: string | null; baseUrl: string | null };
+  envProvider: string | null;
+  envModel: string | null;
+  envBaseUrl: string | null;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <Field
+        label="Provider"
+        htmlFor={`${role}_preset`}
+        hint={envProvider ? `env: ${envProvider}` : undefined}
+      >
+        <select
+          id={`${role}_preset`}
+          name={`${role}_preset`}
+          defaultValue={overrides.preset ?? ""}
+          className={selectStyles}
+        >
+          <option value="">Use .env.local</option>
+          {PRESETS.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </Field>
+      <Field
+        label="Model"
+        htmlFor={`${role}_model`}
+        hint={envModel ? `env: ${envModel}` : undefined}
+      >
+        <input
+          type="text"
+          id={`${role}_model`}
+          name={`${role}_model`}
+          defaultValue={overrides.model ?? ""}
+          placeholder={envModel ?? "e.g. claude-3-opus"}
+          className={inputStyles}
+        />
+      </Field>
+      <Field
+        label="Base URL"
+        htmlFor={`${role}_base_url`}
+        hint={envBaseUrl ? `env: ${envBaseUrl}` : "preset default"}
+      >
+        <input
+          type="text"
+          id={`${role}_base_url`}
+          name={`${role}_base_url`}
+          defaultValue={overrides.baseUrl ?? ""}
+          placeholder={envBaseUrl ?? "leave blank for preset default"}
+          className={inputStyles}
+        />
+      </Field>
+    </div>
+  );
+}
+
+function EnvPanel({ snapshot }: { snapshot: EnvSnapshot }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-900/40">
+      <table className="w-full text-xs">
+        <thead className="bg-slate-100/60 text-left text-[10px] uppercase tracking-wider text-slate-500 dark:bg-slate-800/60 dark:text-slate-400">
+          <tr>
+            <th className="px-4 py-2 font-medium">Var</th>
+            <th className="px-4 py-2 font-medium">Value</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 font-mono dark:divide-slate-800">
+          <EnvRow name="GENERATOR_PROVIDER" value={snapshot.generator.provider} />
+          <EnvRow name="GENERATOR_MODEL" value={snapshot.generator.model} />
+          <EnvRow name="GENERATOR_BASE_URL" value={snapshot.generator.baseUrl} />
+          <EnvRow name="GENERATOR_API_KEY" value={maskKey(snapshot.generator.apiKeySet)} />
+          <EnvRow name="VALIDATOR_PROVIDER" value={snapshot.validator.provider} />
+          <EnvRow name="VALIDATOR_MODEL" value={snapshot.validator.model} />
+          <EnvRow name="VALIDATOR_BASE_URL" value={snapshot.validator.baseUrl} />
+          <EnvRow name="VALIDATOR_API_KEY" value={maskKey(snapshot.validator.apiKeySet)} />
+          <EnvRow name="ANTHROPIC_API_KEY" value={maskKey(snapshot.anthropicApiKeySet)} />
+          <EnvRow name="OPENAI_API_KEY" value={maskKey(snapshot.openaiApiKeySet)} />
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function EnvRow({ name, value }: { name: string; value: string | null }) {
+  return (
+    <tr>
+      <td className="px-4 py-2 text-slate-700 dark:text-slate-300">{name}</td>
+      <td className="px-4 py-2">
+        {value === null ? (
+          <span className="text-slate-400 dark:text-slate-600">unset</span>
+        ) : (
+          <span className="text-slate-700 dark:text-slate-200">{value}</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function maskKey(set: boolean): string | null {
+  return set ? "(set)" : null;
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <header className="mb-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{title}</h2>
+        <p className="text-xs text-slate-500 dark:text-slate-400">{description}</p>
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  hint,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-baseline justify-between">
+        <label
+          htmlFor={htmlFor}
+          className="text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400"
+        >
+          {label}
+        </label>
+        {hint && <span className="text-[10px] text-slate-400 dark:text-slate-500">{hint}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function SaveButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="inline-flex items-center justify-center gap-2 rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400/40 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300"
+    >
+      {pending ? (
+        <>
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Saving…
+        </>
+      ) : (
+        <>
+          <Save className="h-4 w-4" />
+          Save settings
+        </>
+      )}
+    </button>
+  );
+}
+
+const inputStyles =
+  "block w-full rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-mono shadow-sm transition-colors hover:border-slate-400 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400/20 dark:border-slate-700 dark:bg-slate-950/40 dark:hover:border-slate-600 dark:focus:border-slate-500";
+
+const selectStyles =
+  "block w-full rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm shadow-sm transition-colors hover:border-slate-400 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400/20 dark:border-slate-700 dark:bg-slate-950/40 dark:hover:border-slate-600 dark:focus:border-slate-500";

--- a/apps/web/lib/settings-core.ts
+++ b/apps/web/lib/settings-core.ts
@@ -1,0 +1,180 @@
+import type { Preset, ProviderConfig, Role } from "@gauntleet/llm";
+
+export type Difficulty = "easy" | "medium" | "hard";
+
+const PRESETS: readonly Preset[] = ["anthropic", "openai", "lmstudio", "ollama", "custom"];
+const DIFFICULTIES: readonly Difficulty[] = ["easy", "medium", "hard"];
+
+export const PROVIDER_PRESETS: readonly Preset[] = PRESETS;
+
+export interface ProviderOverrides {
+  preset: Preset | null;
+  model: string | null;
+  baseUrl: string | null;
+}
+
+export interface UserSettings {
+  defaultDifficulty: Difficulty | null;
+  /** Topic slug. Validated against the closed TOPICS set at the page boundary, not here. */
+  defaultTopic: string | null;
+  generator: ProviderOverrides;
+  validator: ProviderOverrides;
+  sandboxTimeoutMs: number;
+  sandboxMemoryMb: number;
+}
+
+export const SANDBOX_TIMEOUT_DEFAULT = 5_000;
+export const SANDBOX_MEMORY_DEFAULT = 256;
+
+export const DEFAULT_SETTINGS: UserSettings = {
+  defaultDifficulty: null,
+  defaultTopic: null,
+  generator: { preset: null, model: null, baseUrl: null },
+  validator: { preset: null, model: null, baseUrl: null },
+  sandboxTimeoutMs: SANDBOX_TIMEOUT_DEFAULT,
+  sandboxMemoryMb: SANDBOX_MEMORY_DEFAULT,
+};
+
+/**
+ * Merge a list of stored key/value rows on top of the defaults. Pure so it
+ * can be unit-tested without a DB. Unknown keys are ignored; malformed values
+ * fall back to the default for that key (we'd rather render a working UI than
+ * crash if the JSON column is corrupted).
+ */
+export function mergeSettings(rows: { key: string; value: unknown }[]): UserSettings {
+  const out: UserSettings = {
+    ...DEFAULT_SETTINGS,
+    generator: { ...DEFAULT_SETTINGS.generator },
+    validator: { ...DEFAULT_SETTINGS.validator },
+  };
+  for (const row of rows) {
+    switch (row.key) {
+      case "default_difficulty":
+        out.defaultDifficulty = parseDifficulty(row.value);
+        break;
+      case "default_topic":
+        out.defaultTopic = parseString(row.value);
+        break;
+      case "generator":
+        out.generator = parseProviderOverrides(row.value);
+        break;
+      case "validator":
+        out.validator = parseProviderOverrides(row.value);
+        break;
+      case "sandbox_timeout_ms":
+        out.sandboxTimeoutMs = parsePositiveInt(row.value, SANDBOX_TIMEOUT_DEFAULT);
+        break;
+      case "sandbox_memory_mb":
+        out.sandboxMemoryMb = parsePositiveInt(row.value, SANDBOX_MEMORY_DEFAULT);
+        break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a fully-resolved ProviderConfig for the given role by layering:
+ *   settings override → env vars → preset defaults (handled inside createProvider).
+ *
+ * Pure on its inputs (we pass `env` instead of touching process.env) so the
+ * fallback logic is unit-testable.
+ */
+export function resolveProviderConfig(
+  role: Role,
+  settings: UserSettings,
+  env: Record<string, string | undefined>
+): ProviderConfig | { error: string } {
+  const overrides = role === "GENERATOR" ? settings.generator : settings.validator;
+
+  const presetRaw = overrides.preset ?? env[`${role}_PROVIDER`]?.toLowerCase();
+  if (!presetRaw) {
+    return { error: `${role} provider not configured: set it in Settings or ${role}_PROVIDER` };
+  }
+  if (!isPreset(presetRaw)) {
+    return { error: `${role} provider must be one of ${PRESETS.join("|")} (got "${presetRaw}")` };
+  }
+
+  const model = overrides.model ?? env[`${role}_MODEL`];
+  if (!model) {
+    return { error: `${role} model not configured: set it in Settings or ${role}_MODEL` };
+  }
+
+  const baseUrl = overrides.baseUrl ?? env[`${role}_BASE_URL`];
+  // API keys are intentionally NEVER overridden via settings — they stay in
+  // the .env.local file. Pull from env at the role-level first so role-scoped
+  // keys win over the shared ANTHROPIC_API_KEY / OPENAI_API_KEY fallbacks
+  // that createProvider reads internally.
+  const apiKey = env[`${role}_API_KEY`];
+
+  const config: ProviderConfig = { preset: presetRaw, model };
+  if (baseUrl) config.baseURL = baseUrl;
+  if (apiKey) config.apiKey = apiKey;
+  return config;
+}
+
+/**
+ * Snapshot of which provider env vars are present, with API keys reduced to a
+ * boolean flag. Used by the read-only env panel on the settings page so users
+ * can see what `.env.local` is contributing without exposing secrets.
+ */
+export interface EnvSnapshot {
+  generator: {
+    provider: string | null;
+    model: string | null;
+    baseUrl: string | null;
+    apiKeySet: boolean;
+  };
+  validator: {
+    provider: string | null;
+    model: string | null;
+    baseUrl: string | null;
+    apiKeySet: boolean;
+  };
+  anthropicApiKeySet: boolean;
+  openaiApiKeySet: boolean;
+}
+
+export function snapshotEnv(env: Record<string, string | undefined>): EnvSnapshot {
+  const role = (r: Role) => ({
+    provider: env[`${r}_PROVIDER`] ?? null,
+    model: env[`${r}_MODEL`] ?? null,
+    baseUrl: env[`${r}_BASE_URL`] ?? null,
+    apiKeySet: Boolean(env[`${r}_API_KEY`]),
+  });
+  return {
+    generator: role("GENERATOR"),
+    validator: role("VALIDATOR"),
+    anthropicApiKeySet: Boolean(env["ANTHROPIC_API_KEY"]),
+    openaiApiKeySet: Boolean(env["OPENAI_API_KEY"]),
+  };
+}
+
+// Parsers ─────────────────────────────────────────────────────────────────────
+
+function isPreset(v: string): v is Preset {
+  return (PRESETS as readonly string[]).includes(v);
+}
+
+function parseDifficulty(v: unknown): Difficulty | null {
+  if (typeof v !== "string") return null;
+  return (DIFFICULTIES as readonly string[]).includes(v) ? (v as Difficulty) : null;
+}
+
+function parseString(v: unknown): string | null {
+  if (typeof v !== "string" || v.length === 0) return null;
+  return v;
+}
+
+function parsePositiveInt(v: unknown, fallback: number): number {
+  if (typeof v === "number" && Number.isFinite(v) && v > 0) return Math.floor(v);
+  return fallback;
+}
+
+function parseProviderOverrides(v: unknown): ProviderOverrides {
+  if (!v || typeof v !== "object") return { preset: null, model: null, baseUrl: null };
+  const o = v as Record<string, unknown>;
+  const preset = typeof o.preset === "string" && isPreset(o.preset) ? o.preset : null;
+  const model = typeof o.model === "string" && o.model.length > 0 ? o.model : null;
+  const baseUrl = typeof o.baseUrl === "string" && o.baseUrl.length > 0 ? o.baseUrl : null;
+  return { preset, model, baseUrl };
+}

--- a/apps/web/lib/settings.test.ts
+++ b/apps/web/lib/settings.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SETTINGS,
+  mergeSettings,
+  resolveProviderConfig,
+  snapshotEnv,
+  SANDBOX_MEMORY_DEFAULT,
+  SANDBOX_TIMEOUT_DEFAULT,
+} from "./settings-core.js";
+
+describe("mergeSettings", () => {
+  it("returns defaults when no rows are stored", () => {
+    expect(mergeSettings([])).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it("layers known keys on top of defaults", () => {
+    const result = mergeSettings([
+      { key: "default_difficulty", value: "hard" },
+      { key: "default_topic", value: "graph" },
+      { key: "sandbox_timeout_ms", value: 8000 },
+      { key: "sandbox_memory_mb", value: 512 },
+      {
+        key: "generator",
+        value: { preset: "anthropic", model: "claude-3-opus", baseUrl: null },
+      },
+    ]);
+    expect(result.defaultDifficulty).toBe("hard");
+    expect(result.defaultTopic).toBe("graph");
+    expect(result.sandboxTimeoutMs).toBe(8000);
+    expect(result.sandboxMemoryMb).toBe(512);
+    expect(result.generator).toEqual({
+      preset: "anthropic",
+      model: "claude-3-opus",
+      baseUrl: null,
+    });
+    // Untouched keys still take their defaults.
+    expect(result.validator).toEqual(DEFAULT_SETTINGS.validator);
+  });
+
+  it("ignores unknown keys", () => {
+    const result = mergeSettings([{ key: "totally_made_up", value: "x" }]);
+    expect(result).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it("falls back to defaults when stored values are malformed", () => {
+    const result = mergeSettings([
+      { key: "default_difficulty", value: "extra-spicy" },
+      { key: "default_topic", value: 42 },
+      { key: "sandbox_timeout_ms", value: -100 },
+      { key: "sandbox_memory_mb", value: "two hundred" },
+      { key: "generator", value: "not an object" },
+    ]);
+    expect(result.defaultDifficulty).toBeNull();
+    expect(result.defaultTopic).toBeNull();
+    expect(result.sandboxTimeoutMs).toBe(SANDBOX_TIMEOUT_DEFAULT);
+    expect(result.sandboxMemoryMb).toBe(SANDBOX_MEMORY_DEFAULT);
+    expect(result.generator).toEqual({ preset: null, model: null, baseUrl: null });
+  });
+
+  it("rejects non-preset values inside generator/validator overrides", () => {
+    const result = mergeSettings([
+      { key: "generator", value: { preset: "magic", model: "x", baseUrl: "" } },
+    ]);
+    expect(result.generator).toEqual({ preset: null, model: "x", baseUrl: null });
+  });
+});
+
+describe("resolveProviderConfig", () => {
+  const settingsNoOverrides = mergeSettings([]);
+  const settingsWithOverrides = mergeSettings([
+    {
+      key: "generator",
+      value: {
+        preset: "lmstudio",
+        model: "qwen3-coder-30b",
+        baseUrl: "http://192.168.1.73:1234/v1",
+      },
+    },
+  ]);
+
+  it("uses env when no overrides are stored", () => {
+    const config = resolveProviderConfig("GENERATOR", settingsNoOverrides, {
+      GENERATOR_PROVIDER: "anthropic",
+      GENERATOR_MODEL: "claude-3-opus",
+    });
+    expect(config).toEqual({ preset: "anthropic", model: "claude-3-opus" });
+  });
+
+  it("prefers settings overrides over env", () => {
+    const config = resolveProviderConfig("GENERATOR", settingsWithOverrides, {
+      GENERATOR_PROVIDER: "anthropic",
+      GENERATOR_MODEL: "claude-3-opus",
+      GENERATOR_BASE_URL: "https://example.com",
+    });
+    expect(config).toEqual({
+      preset: "lmstudio",
+      model: "qwen3-coder-30b",
+      baseURL: "http://192.168.1.73:1234/v1",
+    });
+  });
+
+  it("threads role-scoped API key through (never overridden by settings)", () => {
+    const config = resolveProviderConfig("GENERATOR", settingsWithOverrides, {
+      GENERATOR_API_KEY: "sk-from-env",
+    });
+    if ("error" in config) throw new Error("expected config, got error");
+    expect(config.apiKey).toBe("sk-from-env");
+  });
+
+  it("returns an error when neither overrides nor env define a provider", () => {
+    const config = resolveProviderConfig("VALIDATOR", settingsNoOverrides, {});
+    expect("error" in config && config.error).toMatch(/VALIDATOR provider not configured/);
+  });
+
+  it("returns an error when the provider value is not a known preset", () => {
+    const config = resolveProviderConfig("GENERATOR", settingsNoOverrides, {
+      GENERATOR_PROVIDER: "vibes",
+      GENERATOR_MODEL: "x",
+    });
+    expect("error" in config && config.error).toMatch(/must be one of/);
+  });
+
+  it("returns an error when model is missing", () => {
+    const config = resolveProviderConfig("GENERATOR", settingsNoOverrides, {
+      GENERATOR_PROVIDER: "anthropic",
+    });
+    expect("error" in config && config.error).toMatch(/model not configured/);
+  });
+});
+
+describe("snapshotEnv", () => {
+  it("redacts API keys to a boolean flag", () => {
+    const snap = snapshotEnv({
+      GENERATOR_PROVIDER: "anthropic",
+      GENERATOR_MODEL: "claude-3-opus",
+      GENERATOR_API_KEY: "sk-secret",
+      ANTHROPIC_API_KEY: "sk-fallback",
+    });
+    expect(snap.generator).toEqual({
+      provider: "anthropic",
+      model: "claude-3-opus",
+      baseUrl: null,
+      apiKeySet: true,
+    });
+    expect(snap.anthropicApiKeySet).toBe(true);
+    expect(snap.openaiApiKeySet).toBe(false);
+  });
+
+  it("flags both roles independently", () => {
+    const snap = snapshotEnv({
+      VALIDATOR_PROVIDER: "lmstudio",
+      VALIDATOR_MODEL: "qwen",
+    });
+    expect(snap.generator.provider).toBeNull();
+    expect(snap.validator.provider).toBe("lmstudio");
+    expect(snap.validator.apiKeySet).toBe(false);
+  });
+});

--- a/apps/web/lib/settings.ts
+++ b/apps/web/lib/settings.ts
@@ -1,0 +1,53 @@
+import "server-only";
+import { settings as settingsTable, type Db } from "@gauntleet/db";
+import { getDb } from "./db.js";
+import {
+  mergeSettings,
+  type Difficulty,
+  type ProviderOverrides,
+  type UserSettings,
+} from "./settings-core.js";
+
+export {
+  DEFAULT_SETTINGS,
+  PROVIDER_PRESETS,
+  SANDBOX_MEMORY_DEFAULT,
+  SANDBOX_TIMEOUT_DEFAULT,
+  mergeSettings,
+  resolveProviderConfig,
+  snapshotEnv,
+  type Difficulty,
+  type EnvSnapshot,
+  type ProviderOverrides,
+  type UserSettings,
+} from "./settings-core.js";
+
+export function getSettings(db: Db = getDb()): UserSettings {
+  const rows = db.select().from(settingsTable).all();
+  return mergeSettings(rows);
+}
+
+export interface SettingsUpdate {
+  defaultDifficulty?: Difficulty | null;
+  defaultTopic?: string | null;
+  generator?: ProviderOverrides;
+  validator?: ProviderOverrides;
+  sandboxTimeoutMs?: number;
+  sandboxMemoryMb?: number;
+}
+
+export function updateSettings(db: Db, patch: SettingsUpdate): void {
+  const now = new Date();
+  const upsert = (key: string, value: unknown) => {
+    db.insert(settingsTable)
+      .values({ key, value, updatedAt: now })
+      .onConflictDoUpdate({ target: settingsTable.key, set: { value, updatedAt: now } })
+      .run();
+  };
+  if (patch.defaultDifficulty !== undefined) upsert("default_difficulty", patch.defaultDifficulty);
+  if (patch.defaultTopic !== undefined) upsert("default_topic", patch.defaultTopic);
+  if (patch.generator !== undefined) upsert("generator", patch.generator);
+  if (patch.validator !== undefined) upsert("validator", patch.validator);
+  if (patch.sandboxTimeoutMs !== undefined) upsert("sandbox_timeout_ms", patch.sandboxTimeoutMs);
+  if (patch.sandboxMemoryMb !== undefined) upsert("sandbox_memory_mb", patch.sandboxMemoryMb);
+}

--- a/packages/db/drizzle/0003_green_shadowcat.sql
+++ b/packages/db/drizzle/0003_green_shadowcat.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/packages/db/drizzle/meta/0003_snapshot.json
+++ b/packages/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,304 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8c399d6c-3d3e-465e-a4b2-4baa30dfc824",
+  "prevId": "9fb684e1-81fc-4949-acc5-eb116dc635bc",
+  "tables": {
+    "problems": {
+      "name": "problems",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "function_name": {
+          "name": "function_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "return_type": {
+          "name": "return_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_solution": {
+          "name": "reference_solution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_generator": {
+          "name": "input_generator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_tests": {
+          "name": "sample_tests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generator_provider": {
+          "name": "generator_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generator_model": {
+          "name": "generator_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "validation_notes": {
+          "name": "validation_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validator_provider": {
+          "name": "validator_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validator_model": {
+          "name": "validator_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validator_solution": {
+          "name": "validator_solution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_seed_count": {
+          "name": "validation_seed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "submissions": {
+      "name": "submissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failed_at_index": {
+          "name": "failed_at_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_note": {
+          "name": "failure_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_ms": {
+          "name": "runtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tests_passed": {
+          "name": "tests_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tests_total": {
+          "name": "tests_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submissions_problem_id_problems_id_fk": {
+          "name": "submissions_problem_id_problems_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "problems",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777402670132,
       "tag": "0002_right_lockheed",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1777517718098,
+      "tag": "0003_green_shadowcat",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -83,3 +83,18 @@ export const submissions = sqliteTable("submissions", {
 
 export type Submission = typeof submissions.$inferSelect;
 export type NewSubmission = typeof submissions.$inferInsert;
+
+/**
+ * Single-row-per-key settings store. Values are JSON-encoded so the UI can
+ * persist heterogeneous data (numbers, strings, nullable provider configs)
+ * without a migration each time we add a knob. Validation lives in the app
+ * layer, not in the DB.
+ */
+export const settings = sqliteTable("settings", {
+  key: text("key").primaryKey(),
+  value: text("value", { mode: "json" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+});
+
+export type SettingsRow = typeof settings.$inferSelect;
+export type NewSettingsRow = typeof settings.$inferInsert;


### PR DESCRIPTION
## Summary
- New \`settings\` table (key/value JSON) backing a real /settings page.
- **Defaults** for the Generate form (difficulty + topic) — picked up by the home page.
- **Provider overrides** (preset / model / base URL) for the generator and validator. Layered as: settings → \`.env.local\` → preset defaults. API keys are intentionally never stored in the DB; they stay in \`.env.local\`.
- **Sandbox limits** (timeout ms, memory MB), threaded through Run, Submit, and validation.
- Read-only **\`.env.local\` snapshot** panel — masks API keys to \`(set)\` so users can see what the running process has loaded without exposing secrets.

## Notes
- Pure \`mergeSettings\` / \`resolveProviderConfig\` / \`snapshotEnv\` live in \`settings-core.ts\` (no \`server-only\` import) so vitest can exercise them. The DB-bound \`getSettings\` / \`updateSettings\` live in \`settings.ts\` and re-export the pure pieces.
- 13 new tests covering the layering, malformed-row tolerance, role-scoped key fallback, and the env snapshot redaction. 137 total, all passing.
- Saving settings revalidates \`/\` so the Generate form's defaults update immediately.

## Test plan
- [x] \`pnpm typecheck\`, \`pnpm lint\`, \`pnpm format:check\`, \`pnpm test\`, \`pnpm build\` all green
- [x] Live SSR probe with the dev server:
  - \`/settings\` renders all 10 form fields + the env panel
  - Inserting \`default_difficulty=hard\` + \`default_topic=graph\` directly into the DB causes the home Generate form to start with \`hard\` + \`graph\` selected
  - Wiping the settings table reverts to the previous \`medium\` / \`arrays\` defaults
- [x] Manual click-through: change defaults → save → confirm home form updates → confirm reload preserves the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)